### PR TITLE
Update humble devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -138,7 +138,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: foxy-devel
+    devel_branch: humble
     last_version: 1.1.3
     name: rqt_publisher
     patches: null


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for humble to match the source branch as specified in https://github.com/ros/rosdistro/humble/distribution.yaml .
