### PR TITLE
Update lyrical devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -244,7 +244,7 @@ tracks:
       :{release_inc} --os-name rhel
     - git-bloom-generate -y rosdynrpm --prefix release/:{ros_distro} :{ros_distro}
       -i :{release_inc} --require-os fedora rhel
-    devel_branch: rolling
+    devel_branch: lyrical
     last_version: 1.10.2
     name: rqt_publisher
     patches: null


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for lyrical to match the source branch as specified in https://github.com/ros/rosdistro/lyrical/distribution.yaml .
Part of https://github.com/ros2/release-tracking/issues/57
